### PR TITLE
chore: define the shared ruff standard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,15 @@ repos:
         language: system
         types: [python]
       # Run the linter (inherits config from pyproject.toml)
+      # The tests are linted through per-file-ignores, not excluded — see the
+      # "tests/**" table in pyproject.toml. An exclude here would put them back
+      # out of scope at commit time and make that table dead config locally.
       - id: ruff-check
         name: ruff linter
         entry: uv run ruff check
         language: system
         types: [python]
         args: [--fix]
-        exclude: ^tests/
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,11 @@ show-fixes = true
 # Shared standard for all SBB Python repositories.
 # Never use extend-select: it inherits ruff's implicit default, which widened in
 # ruff 0.16 and broke CI everywhere. Keep preview off, preview rules churn.
+#
+# ALL still means "every stable rule in the installed ruff", so a ruff bump can
+# introduce findings. That is the accepted trade: a clean bump automerges, and a
+# dirty one turns the new rules into a change someone reads. What this config
+# removes is the version dependency we did not choose and could not see.
 select = ["ALL"]
 preview = false
 ignore = [
@@ -61,7 +66,8 @@ ignore = [
     # Not our convention
     "D",       # docstrings are optional, we mandate no docstring style
     "CPY001",  # we ship no copyright headers
-    "FIX002",  # a TODO is a normal marker, not a defect
+    "FIX002",  # a TODO is a normal marker, not a defect; TD002 and TD003 still
+               # require it to name an author and link an issue
     "EM101",   # a literal at the raise site reads better than a temp name
     "EM102",   # same for an f-string
     "TRY003",  # we want the full message where the raise happens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,12 @@ select = ["ALL"]
 preview = false
 ignore = [
     # ruff format owns this formatting decision. COM812 is the only rule ruff
-    # itself reports as conflicting; the Q00x rules were measured across all
-    # eight repositories and silence nothing, so quote-style below carries that
-    # decision instead of an ignore.
+    # itself reports as conflicting, so it is the only entry here. The Q00x rules
+    # are deliberately absent rather than ignored: Q000, Q002 and Q003 fire
+    # nowhere across the eight repositories, and Q001 fires in one of them but is
+    # auto-fixable and ruff format runs before ruff check in both tox.ini and
+    # pre-commit, so the formatter resolves it. The quote decision itself is
+    # pinned at the bottom of this file, on both the format and the lint side.
     "COM812",  # trailing comma
 
     # Not our convention
@@ -116,10 +119,18 @@ max-args = 10
 # glob named "ignore" that matches no file: it is accepted, it silences
 # nothing, and ruff says nothing. Add such a rule to the ignore list above.
 
+[tool.ruff.lint.flake8-quotes]
+# The lint half of the quote decision. These are what Q000, Q001 and Q002 read,
+# and with the Q rules enabled they decide a lint result, so they are stated
+# rather than inherited. Keep them equal to format.quote-style below: diverge and
+# Q000 fires on the string the formatter just rewrote.
+inline-quotes = "double"
+multiline-quotes = "double"
+docstring-quotes = "double"
+
 [tool.ruff.format]
 line-ending = "lf"
-# Pinned rather than left to the default: it is what makes the Q00x lint rules
-# redundant, so the decision has to be stated where the formatter reads it.
+# The format half. Changing this means changing flake8-quotes above in step.
 quote-style = "double"
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,11 @@ show-fixes = true
 select = ["ALL"]
 preview = false
 ignore = [
-    # ruff format owns this formatting decision
+    # ruff format owns this formatting decision. COM812 is the only rule ruff
+    # itself reports as conflicting; the Q00x rules were measured across all
+    # eight repositories and silence nothing, so quote-style below carries that
+    # decision instead of an ignore.
     "COM812",  # trailing comma
-    "Q000",    # inline string quotes
-    "Q001",    # multiline string quotes
-    "Q002",    # docstring quotes
-    "Q003",    # escaped quotes
 
     # Not our convention
     "D",       # docstrings are optional, we mandate no docstring style
@@ -119,6 +118,9 @@ max-args = 10
 
 [tool.ruff.format]
 line-ending = "lf"
+# Pinned rather than left to the default: it is what makes the Q00x lint rules
+# redundant, so the decision has to be stated where the formatter reads it.
+quote-style = "double"
 
 [tool.mypy]
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,13 @@ max-args = 10
     "PLR0915", # same, for its statements
 ]
 
-# Repository-specific ignores belong below this line, each with a reason.
+# Repository-specific per-file ignores belong below this line, each with a
+# reason, and each in the "glob" = ["RULE"] form of the table above.
+#
+# A repository-wide ignore does NOT go here. This is still
+# [tool.ruff.lint.per-file-ignores], so a bare ignore = ["RULE"] parses as a
+# glob named "ignore" that matches no file: it is accepted, it silences
+# nothing, and ruff says nothing. Add such a rule to the ignore list above.
 
 [tool.ruff.format]
 line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,9 @@ max-args = 10
 inline-quotes = "double"
 multiline-quotes = "double"
 docstring-quotes = "double"
+# The fourth option, and the one that decides whether Q003 runs at all: set it to
+# false and the rule stops reporting with nothing red to show for it.
+avoid-escape = true
 
 [tool.ruff.format]
 line-ending = "lf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,18 +45,65 @@ fix = true
 show-fixes = true
 
 [tool.ruff.lint]
+# Shared standard for all SBB Python repositories.
+# Never use extend-select: it inherits ruff's implicit default, which widened in
+# ruff 0.16 and broke CI everywhere. Keep preview off, preview rules churn.
 select = ["ALL"]
+preview = false
 ignore = [
-    "D",      # pydocstyle — enable when docstring conventions are established
-    "ANN",    # flake8-annotations — mypy handles type checking
-    "COM",    # flake8-commas — formatter handles trailing commas
-    "ISC",    # flake8-implicit-str-concat — conflicts with formatter
+    # ruff format owns this formatting decision
+    "COM812",  # trailing comma
+    "Q000",    # inline string quotes
+    "Q001",    # multiline string quotes
+    "Q002",    # docstring quotes
+    "Q003",    # escaped quotes
+
+    # Not our convention
+    "D",       # docstrings are optional, we mandate no docstring style
+    "CPY001",  # we ship no copyright headers
+    "FIX002",  # a TODO is a normal marker, not a defect
+    "EM101",   # a literal at the raise site reads better than a temp name
+    "EM102",   # same for an f-string
+    "TRY003",  # we want the full message where the raise happens
+    "TRY400",  # a handled error is logged without a traceback
+    "TRY401",  # the exception text belongs on the log line, not only in the traceback
+    "G004",    # we ingest plain log lines, not templates, so f-strings are fine
+    "ANN401",  # Any is correct at JSON and **kwargs boundaries
+    "FBT001",  # a boolean query parameter is part of the HTTP API
+    "FBT002",  # same, with a default
 ]
 
+[tool.ruff.lint.mccabe]
+max-complexity = 15
+
+[tool.ruff.lint.pylint]
+max-args = 10
+
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = [
-    "S101" # No assert rule (bandit)
+"tests/**" = [
+    "S101",    # assert is how a test states its expectation
+    "S105",    # test credentials are fake by construction
+    "S106",    # same, passed as an argument
+    "S108",    # a temp path in a test is not a shared temp path
+    "S603",    # tests run known helper binaries
+    "S607",    # those binaries come from PATH on purpose
+    "SLF001",  # a test may assert on internal state
+    "PLC0415", # a local import is how a test patches a module
+    "ANN",     # a test signature carries no type information
+    "ARG",     # a fixture argument is used by pytest, not by the body
+    "PLR2004", # a literal is readable test data
+    "PT",      # unittest style is allowed next to pytest style
+    "E402",    # a test may import after patching
+    "TC",      # a test module is imported once, deferring imports buys nothing
+    "S104",    # a host string in test data is not a binding
+    "S314",    # a test parses the XML fixture it wrote itself
+    "FBT003",  # mock.patch takes the replacement value positionally
+    "C901",    # a fixture is linear setup, splitting it hides the order
+    "PLR0912", # same, for its branches
+    "PLR0915", # same, for its statements
 ]
+
+# Repository-specific ignores belong below this line, each with a reason.
 
 [tool.ruff.format]
 line-ending = "lf"


### PR DESCRIPTION
This file becomes the source of truth the service repositories copy from.
The seven companion PRs adopt it.

## What broke

Ruff 0.16 widened its implicit default rule selection from `E,F` to a broad
set. Six repositories used `extend-select`, so their enabled rules were a
function of the installed ruff version, and the bump turned every Renovate
ruff PR red. Two more used `select = ["ALL"]` with `preview = true`, which
adds unstable rules on every release.

## The standard

Three rules keep the lint result a function of the code:

1. Always state the rule set explicitly. Never `extend-select`.
2. Keep `preview = false`. Preview rules churn between releases.
3. Lint the tests through `per-file-ignores` instead of hiding them behind
   `exclude`. Five repositories excluded `tests/*` while also declaring
   `per-file-ignores` for `tests/*`, which was dead config: ruff saw no Python
   files there at all.

Every ignore was measured against all eight repositories and carries the
reason it is there, on the merits rather than on the cost of fixing. Entries a
threshold already covers are absent, so `PLR0913` answers to `max-args` and
`C901` to `max-complexity` instead of being silenced. Rules that fire in a
single repository stay out of this list and are fixed there.

## Note on suppressions

A `noqa` is itself version-dependent. `CPY001`, `LOG004` and `PLR0917` each
exist in one ruff version and not the other, so a suppression fails on one
side and its absence fails on the other. Where that happened, the code was
changed instead.