### PR TITLE
chore: record that the format-before-check ordering is load-bearing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,8 +61,10 @@ ignore = [
     # are deliberately absent rather than ignored: Q000, Q002 and Q003 fire
     # nowhere across the eight repositories, and Q001 fires in one of them but is
     # auto-fixable and ruff format runs before ruff check in both tox.ini and
-    # pre-commit, so the formatter resolves it. The quote decision itself is
-    # pinned at the bottom of this file, on both the format and the lint side.
+    # pre-commit, so the formatter resolves it. That ordering is load-bearing:
+    # reverse it — the upstream ruff-pre-commit example puts check first — and
+    # these entries have to come back. The quote decision itself is pinned at the
+    # bottom of this file, on both the format and the lint side.
     "COM812",  # trailing comma
 
     # Not our convention


### PR DESCRIPTION
Follow-up to the merged ruff standard, one comment block.

The `Q00x` entries are absent from the `ignore` list because `ruff format` runs
ahead of `ruff check` in both `tox.ini` and `.pre-commit-config.yaml`, so the
formatter resolves a `Q001` finding before the linter reads the file. Nothing at
the hook site said that the ordering carries the decision.

The upstream `ruff-pre-commit` example orders `ruff-check` before `ruff-format`, so
a repository that copies the hook block in that order — or a maintainer who
reorders the hooks later — turns a previously-resolved `Q001` into a red hook with
no comment explaining why. The dependency is now stated next to the entries it
protects.

Comment only; `ruff format --check` and `ruff check` pass unchanged.
