### PR TITLE
chore: use the reusable Claude workflow and drop the python-sbb-polarion linter hook

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,3 +1,4 @@
+---
 name: Claude Code
 on:
   issue_comment:
@@ -8,38 +9,15 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+permissions: {}
 jobs:
   claude:
-    if: |
-      github.actor != 'renovate[bot]' && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
-    runs-on: ubuntu-latest
+    uses: SchweizerischeBundesbahnen/github-workflows-polarion/.github/workflows/reusable-claude.yml@main
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-      actions: read  # Required for Claude to read CI results on PRs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
-        with:
-          fetch-depth: 1
-          persist-credentials: true
-      - name: Run Claude Code
-        id: claude
-        uses: anthropics/claude-code-action@6b082c41935b4c8a3b8b0ef85ba4ba4d9eeb8975  # v1.0.189
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-
-          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
-
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://docs.anthropic.com/en/docs/claude-code/sdk#command-line for available options
-          # claude_args: '--model claude-opus-4-1-20250805 --allowed-tools Bash(gh pr:*)'
+      actions: read
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,16 +64,6 @@ repos:
         pass_filenames: false  # Don't pass individual files, use the specified path
   - repo: local
     hooks:
-      # Custom code style linter (PSP001-PSP005)
-      - id: python-sbb-polarion-linter
-        name: python-sbb-polarion code style linter
-        entry: uv run python -m python_sbb_polarion.linter
-        language: system
-        types: [python]
-        pass_filenames: false
-        files: ^python_sbb_polarion/
-  - repo: local
-    hooks:
       - id: uv-lock
         name: uv-lock
         entry: uv lock --check


### PR DESCRIPTION
Two template synchronisation gaps found in the same review, both of which every consumer sync currently has to make a judgement call on.

## Closes #127 — remove the python-sbb-polarion linter hook

The hook could not run in this template, nor in any repository generated from it:

- Its entry executes `python -m python_sbb_polarion.linter`. That module lives inside the source tree of the `python-sbb-polarion` repository itself (`python_sbb_polarion/linter/`) and the package is not published to PyPI, so there is nothing a consumer could declare as a dependency. It was also absent from `pyproject.toml` and `uv.lock` here.
- Its `files: ^python_sbb_polarion/` filter matched a directory that exists in no other repository, so the hook silently never selected a file.

Of the two resolutions offered in the issue, the second applies: option 1 would require the linter to be installable, and it is not. The linter therefore stays with `python-sbb-polarion` as repository-local tooling. Nothing else in this repository referenced it — the removal is confined to `.pre-commit-config.yaml`.

## Closes #124 — migrate claude.yml to the reusable workflow

`.github/workflows/claude.yml` becomes a thin caller of `github-workflows-polarion/.github/workflows/reusable-claude.yml@main`, matching the pattern `claude-code-review.yml` already follows here. The prerequisite is met: the reusable workflow is present on `main`, and `python-sbb-polarion` already runs exactly this caller.

Beyond removing about 30 lines of boilerplate per consumer, the migration closes a real gap in the bot filter. The inline job filtered on `github.actor != 'renovate[bot]'`; the reusable workflow filters on `github.event.sender.type != 'Bot'`, which also covers bot reviewers whose login carries no `[bot]` suffix, Copilot among them. With OAuth authentication `claude-code-action` fails with HTTP 401 when the triggering actor has no write access, so those senders had to be excluded and were not.

The caller additionally inherits settings the inline job never passed: `timeout-minutes: 30`, `track_progress: true`, `additional_permissions: actions: read`, and `claude_args: --max-turns 30 --model opus`. The `claude-code-action` pin now lives in the reusable workflow alone, so Renovate bumps it in one place instead of drifting per repository — the two had already diverged, this template at v1.0.189 against the reusable workflow's v1.0.183. The file also gains the `---` document start and the workflow level `permissions: {}` that every other workflow here carries.

## Verification

`pre-commit run` over both changed files passes, `actionlint` and `zizmor` included. The linter hook no longer appears in the hook list, confirming the removal took effect.

## Follow-up, not in this PR

`python-requirements-inspector` adopted the inline `claude.yml` through SchweizerischeBundesbahnen/python-requirements-inspector#172 while resynchronising with this template, so it needs its own migration once this lands. The commented-out PyPI publishing block in `ci.yml` is the same class of leakage and remains tracked separately in #128.
