### PR TITLE
chore: mark where repository-specific ignores go

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,10 @@ ignore = [
     "ANN401",  # Any is correct at JSON and **kwargs boundaries
     "FBT001",  # a boolean query parameter is part of the HTTP API
     "FBT002",  # same, with a default
+
+    # Repository-specific entries belong below this line, each with a reason, so
+    # the next sync of the shared block above can tell the two apart. Without the
+    # line a local entry looks shared and the sync deletes it silently.
 ]
 
 [tool.ruff.lint.mccabe]
@@ -119,7 +123,8 @@ max-args = 10
 # A repository-wide ignore does NOT go here. This is still
 # [tool.ruff.lint.per-file-ignores], so a bare ignore = ["RULE"] parses as a
 # glob named "ignore" that matches no file: it is accepted, it silences
-# nothing, and ruff says nothing. Add such a rule to the ignore list above.
+# nothing, and ruff says nothing. Add such a rule below the marker inside the
+# ignore list above.
 
 [tool.ruff.lint.flake8-quotes]
 # The lint half of the quote decision. These are what Q000, Q001 and Q002 read,


### PR DESCRIPTION
Follow-up to #130, from a review observation on the companion PR in
python-sbb-polarion.

`[tool.ruff.lint.per-file-ignores]` already carries a marker separating the
shared block from repository-specific globs. The `ignore` list does not, yet its
header declares it the shared standard for all repositories.

So a repository that adds a local entry there puts it between two shared ones,
where it looks shared. When the block is next re-synced from this template,
whoever does it cannot tell the line was local, and the reviewers of that sync
see a plain deletion with no reason attached. The rule then starts firing on
code that PR never touched.

This adds the same marker to the `ignore` list and points the per-file-ignores
note at it, so the two halves of the file follow one convention.

Verified: ruff 0.15.22 and 0.16.2 both clean.